### PR TITLE
Fix/non blocking cmd execution

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -1,6 +1,26 @@
+/*
+ * commands.c — CMon command execution layer
+ *
+ * CHANGED (non-blocking rewrite per GitHub issue):
+ *  - run_cmd_argv() now forks, sets the pipe read-end O_NONBLOCK,
+ *    and returns immediately after a successful fork.
+ *  - Output draining and child reaping are handled asynchronously
+ *    by the libevent event loop via registered callbacks
+ *    (pipe_read_cb and sigchld_cb).
+ *  - Both blocking waitpid() calls that existed on the original lines
+ *    56 and 108 are gone; all waitpid() calls use WNOHANG.
+ *  - Callers (validate_and_run / validate_and_run_arg in main.c)
+ *    receive an immediate "job accepted" response; result tracking
+ *    is delegated to the separate job-queue project.
+ *  - The public API of every command function is unchanged.
+ */
+
 #include "commands.h"
 #include "arena.h"
 #include "utils.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -8,17 +28,282 @@
 #include <sys/wait.h>
 #include <unistd.h>
 
+/* libevent headers needed for async I/O and signal handling */
+#include <event2/event.h>
+
 #define SERVER_BINARY "target"
 
-char *run_cmd_argv(const char *path, char *const argv[], int *exit_code_out) {
-    struct timeval start, end;
-    gettimeofday(&start, NULL);
+/* ------------------------------------------------------------------ */
+/* Job context — one per in-flight command                             */
+/* ------------------------------------------------------------------ */
 
-    *exit_code_out = -1;
+/*
+ * cmd_job_t tracks everything needed to drain the pipe and reap the
+ * child without blocking the event loop.
+ *
+ * Lifetime: heap-allocated just before fork(); freed inside sigchld_cb
+ * once the child has exited and the pipe has been fully drained.
+ */
+typedef struct cmd_job {
+    pid_t        pid;           /* child PID                           */
+    int          pipe_fd;       /* read end of the output pipe         */
+    struct event *pipe_ev;      /* libevent READ event on pipe_fd      */
+    struct event *sigchld_ev;   /* libevent SIGCHLD event (shared)     */
+    struct timeval start;       /* wall-clock start time               */
+
+    /* growing output buffer (arena-backed) */
+    char   *output;
+    size_t  capacity;
+    size_t  total;
+
+    /* path string kept for log_exec() */
+    char    path[256];
+} cmd_job_t;
+
+/* ------------------------------------------------------------------ */
+/* Forward declarations of async callbacks                             */
+/* ------------------------------------------------------------------ */
+
+static void pipe_read_cb(evutil_socket_t fd, short what, void *arg);
+static void sigchld_cb(evutil_socket_t sig, short what, void *arg);
+
+/*
+ * Global libevent base pointer — set once by run_cmd_argv_set_base()
+ * before the first command is dispatched.  The server's main() already
+ * holds this value; we just need a reference to it here so the command
+ * layer can register events without threading it through every call.
+ */
+static struct event_base *g_base = NULL;
+
+/*
+ * Shared SIGCHLD event.  A single evsignal_new is sufficient because
+ * SIGCHLD is delivered once per dead child (or coalesced); sigchld_cb
+ * loops with waitpid(-1, …, WNOHANG) to reap all pending children.
+ */
+static struct event *g_sigchld_ev = NULL;
+
+/*
+ * Linked list of active jobs.  sigchld_cb scans this list to match a
+ * reaped PID to its cmd_job_t so it can finalise logging and free
+ * resources.
+ */
+static cmd_job_t *g_job_list_head = NULL;
+
+/* ------------------------------------------------------------------ */
+/* Public initialisation — call once from main() after event_base_new  */
+/* ------------------------------------------------------------------ */
+
+void run_cmd_argv_init(struct event_base *base) {
+    g_base = base;
+
+    /*
+     * Register a persistent SIGCHLD handler.  EV_PERSIST means it
+     * stays active across multiple deliveries, which is what we want.
+     */
+    g_sigchld_ev = evsignal_new(base, SIGCHLD, sigchld_cb, NULL);
+    if (!g_sigchld_ev) {
+        log_error("evsignal_new(SIGCHLD) failed");
+        return;
+    }
+    event_add(g_sigchld_ev, NULL);
+}
+
+/* ------------------------------------------------------------------ */
+/* Async callbacks                                                      */
+/* ------------------------------------------------------------------ */
+
+/*
+ * pipe_read_cb — called by libevent whenever the child's stdout/stderr
+ * pipe has data ready to read (or the write-end has been closed).
+ *
+ * Because the fd is O_NONBLOCK we read in a tight loop until EAGAIN or
+ * EOF.  The output is appended to the job's arena buffer, growing it as
+ * needed.
+ */
+static void pipe_read_cb(evutil_socket_t fd, short what, void *arg) {
+    cmd_job_t *job = (cmd_job_t *)arg;
+    (void)what;
+
+    char tmp[512];
+    ssize_t n;
+
+    while ((n = read(fd, tmp, sizeof(tmp))) > 0) {
+        /* Grow arena buffer if needed */
+        if (job->total + (size_t)n >= job->capacity) {
+            size_t new_cap = job->capacity * 2;
+            char *grown = allocate(new_cap);
+            if (!grown) {
+                log_error("allocate failed during pipe_read_cb growth — truncating output");
+                break;
+            }
+            memcpy(grown, job->output, job->total);
+            deallocate(job->output);
+            job->output   = grown;
+            job->capacity = new_cap;
+        }
+        memcpy(job->output + job->total, tmp, (size_t)n);
+        job->total += (size_t)n;
+    }
+
+    if (n == 0 || (n == -1 && errno != EAGAIN && errno != EWOULDBLOCK)) {
+        /*
+         * EOF or a real read error — the child has closed its side of
+         * the pipe (i.e., it has exited or its fd was closed).  Stop
+         * listening; sigchld_cb will finalise the job.
+         */
+        event_del(job->pipe_ev);
+        event_free(job->pipe_ev);
+        job->pipe_ev = NULL;
+
+        close(job->pipe_fd);
+        job->pipe_fd = -1;
+    }
+    /* If n == -1 && EAGAIN: no data right now — libevent will call us again */
+}
+
+/*
+ * sigchld_cb — called by libevent on SIGCHLD.
+ *
+ * Reaps all dead children with waitpid(-1, …, WNOHANG) (so we never
+ * block), then looks each reaped PID up in g_job_list_head to log
+ * the result and free job resources.
+ */
+static void sigchld_cb(evutil_socket_t sig, short what, void *arg) {
+    (void)sig;
+    (void)what;
+    (void)arg;
+
+    int status;
+    pid_t pid;
+
+    /*
+     * Loop until there are no more children to reap.  This handles
+     * the case where multiple children exit between SIGCHLD deliveries
+     * (the kernel may coalesce signals).
+     */
+    while ((pid = waitpid(-1, &status, WNOHANG)) > 0) {
+
+        /* Find the matching job */
+        cmd_job_t *prev = NULL;
+        cmd_job_t *job  = g_job_list_head;
+        while (job && job->pid != pid) {
+            prev = job;
+            job  = (cmd_job_t *)job->pipe_ev; /* abuse: see note below */
+            /*
+             * NOTE: We cannot store a true "next" pointer inside
+             * cmd_job_t without changing the struct layout visible to
+             * callers.  A simple solution is to keep a parallel singly-
+             * linked list via a separate wrapper; but since the issue
+             * says "no new endpoints, no server changes, no protocol
+             * changes", we embed the next pointer directly below.
+             */
+        }
+
+        /* ---- proper linked-list walk (see struct above for next ptr) ---- */
+        /*
+         * Re-do the walk correctly.  The earlier attempt above is
+         * deliberately left so the reader can see the reasoning; the
+         * compiler will eliminate the dead path.  The actual walk uses
+         * the `sigchld_ev` field temporarily repurposed as `next` before
+         * the event is created — but that is fragile.  Instead we use a
+         * simple singly-linked list embedded in cmd_job_t via the
+         * already-declared field below.  See the revised struct and init
+         * code.
+         */
+        (void)prev; /* suppress unused-variable warning from above */
+
+        if (!job) {
+            /* Not one of ours — could be a pre-existing child */
+            continue;
+        }
+
+        /* -------------------------------------------------------------- */
+        /* Job found: finalise                                              */
+        /* -------------------------------------------------------------- */
+
+        /* Remove from global list */
+        if (prev)
+            *((cmd_job_t **)((char *)prev + offsetof(cmd_job_t, sigchld_ev))) = NULL;
+        else
+            g_job_list_head = NULL;
+
+        /* If the pipe event is still active, drain any remaining bytes */
+        if (job->pipe_ev) {
+            event_del(job->pipe_ev);
+            event_free(job->pipe_ev);
+            job->pipe_ev = NULL;
+        }
+        if (job->pipe_fd >= 0) {
+            /* Final synchronous drain — child is dead so this won't block */
+            char tmp[512];
+            ssize_t n;
+            while ((n = read(job->pipe_fd, tmp, sizeof(tmp))) > 0) {
+                if (job->total + (size_t)n < job->capacity) {
+                    memcpy(job->output + job->total, tmp, (size_t)n);
+                    job->total += (size_t)n;
+                }
+            }
+            close(job->pipe_fd);
+            job->pipe_fd = -1;
+        }
+
+        /* Null-terminate output */
+        if (job->total >= job->capacity) {
+            /* Rare edge: exactly full — drop last byte for NUL */
+            job->total = job->capacity - 1;
+        }
+        job->output[job->total] = '\0';
+
+        /* Compute duration */
+        struct timeval end;
+        gettimeofday(&end, NULL);
+        double duration = (end.tv_sec  - job->start.tv_sec) +
+                          (end.tv_usec - job->start.tv_usec) / 1000000.0;
+
+        /* Decode exit status */
+        int exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+
+        log_exec(job->path, exit_code, duration);
+
+        /* Free resources */
+        deallocate(job->output);
+        free(job);
+    }
+}
+
+/* ------------------------------------------------------------------ */
+/* run_cmd_argv — public, now non-blocking                             */
+/* ------------------------------------------------------------------ */
+
+/*
+ * CHANGED: This function no longer blocks.
+ *
+ * It forks the child, sets up the non-blocking pipe, registers async
+ * events, and returns immediately.  The return value is always NULL
+ * and *exit_code_out is set to 0 ("accepted") so that the existing
+ * callers in main.c can send an immediate "job accepted" response
+ * to the client.
+ *
+ * The previous behaviour (wait for child, return output) required two
+ * blocking waitpid() calls:
+ *   • The error path at (original) line 56 — gone.
+ *   • The main reap at (original) line 108 — gone.
+ *
+ * Both are replaced by the WNOHANG loop in sigchld_cb above.
+ */
+char *run_cmd_argv(const char *path, char *const argv[], int *exit_code_out) {
+    if (!g_base) {
+        log_error("run_cmd_argv: event base not set — call run_cmd_argv_init() first");
+        *exit_code_out = -1;
+        return NULL;
+    }
+
+    *exit_code_out = 0; /* "accepted" — actual exit code logged asynchronously */
 
     int pipefd[2];
     if (pipe(pipefd) == -1) {
         log_error("pipe failed");
+        *exit_code_out = -1;
         return NULL;
     }
 
@@ -27,11 +312,12 @@ char *run_cmd_argv(const char *path, char *const argv[], int *exit_code_out) {
         log_error("fork failed");
         close(pipefd[0]);
         close(pipefd[1]);
+        *exit_code_out = -1;
         return NULL;
     }
 
     if (pid == 0) {
-        // child
+        /* ---- child ---- */
         dup2(pipefd[1], STDOUT_FILENO);
         dup2(pipefd[1], STDERR_FILENO);
         close(pipefd[0]);
@@ -42,91 +328,104 @@ char *run_cmd_argv(const char *path, char *const argv[], int *exit_code_out) {
         _exit(127);
     }
 
-    // parent
-    close(pipefd[1]);
+    /* ---- parent ---- */
+    close(pipefd[1]); /* close write end — child owns it */
 
-    // Dynamic allocation using arena
-    size_t capacity = 512;
-    size_t total = 0;
-    char *output = allocate(capacity);
-
-    if (!output) {
-        log_error("allocate failed in run_cmd_argv");
+    /* Make the read end non-blocking so pipe_read_cb never stalls */
+    int flags = fcntl(pipefd[0], F_GETFL, 0);
+    if (flags == -1 || fcntl(pipefd[0], F_SETFL, flags | O_NONBLOCK) == -1) {
+        log_error("fcntl O_NONBLOCK failed — falling back to blocking read");
+        /*
+         * Degraded path: if we cannot set O_NONBLOCK we close the fd
+         * and abandon output capture rather than block the event loop.
+         */
         close(pipefd[0]);
-        waitpid(pid, NULL, 0);
+        /* sigchld_cb will still reap the child via WNOHANG */
+        cmd_job_t *job_nb = calloc(1, sizeof(cmd_job_t));
+        if (job_nb) {
+            job_nb->pid     = pid;
+            job_nb->pipe_fd = -1;
+            job_nb->output  = allocate(1);
+            if (job_nb->output) job_nb->output[0] = '\0';
+            job_nb->capacity = 1;
+            gettimeofday(&job_nb->start, NULL);
+            strncpy(job_nb->path, path, sizeof(job_nb->path) - 1);
+            /* prepend to global list */
+            job_nb->sigchld_ev   = (struct event *)g_job_list_head;
+            g_job_list_head = job_nb;
+        }
         return NULL;
     }
 
-    char temp_buf[512];
-    ssize_t n;
-    while ((n = read(pipefd[0], temp_buf, sizeof(temp_buf))) > 0) {
-        if (total + n >= capacity) {
-            // Grow buffer
-            size_t new_capacity = capacity * 2;
-            // Cap at some reasonable limit if needed, e.g. 1MB?
-            // The user said "shouldnt really bother us to have super large size"
-
-            char *new_output = allocate(new_capacity);
-            if (!new_output) {
-                log_error("allocate failed during growth");
-                break; // Stop reading, return what we have
-            }
-
-            memcpy(new_output, output, total);
-            deallocate(output);
-            output = new_output;
-            capacity = new_capacity;
-        }
-
-        memcpy(output + total, temp_buf, n);
-        total += n;
-    }
-
-    // Ensure null termination (might need 1 more byte if full)
-    if (total == capacity) {
-        // This is a rare edge case where we filled exactly.
-        // We need 1 byte for 0. Allocating just 1 byte more essentially means
-        // growing substantially in arena terms (min chunk), but we must do it.
-        // Or we can just grow by small amount.
-        size_t new_capacity = capacity + 512; // Grow by one chunk
-        char *new_output = allocate(new_capacity);
-        if (new_output) {
-            memcpy(new_output, output, total);
-            deallocate(output);
-            output = new_output;
-            // capacity = new_capacity;
-        } else {
-            // If fails, we truncate the last byte to fit null?
-            // Or strict fail? Truncating is safer for stability.
-            total--;
-        }
-    }
-    output[total] = '\0';
-    close(pipefd[0]);
-
-    int status;
-    waitpid(pid, &status, 0);
-
-    gettimeofday(&end, NULL);
-    double duration = (end.tv_sec - start.tv_sec) + (end.tv_usec - start.tv_usec) / 1000000.0;
-
-    int exit_code = 0;
-    if (WIFEXITED(status)) {
-        exit_code = WEXITSTATUS(status);
-    } else {
-        exit_code = -1;
-    }
-
-    log_exec(path, exit_code, duration);
-    *exit_code_out = exit_code;
-
-    if (exit_code == 127) {
-        deallocate(output);
+    /* Allocate job context */
+    cmd_job_t *job = calloc(1, sizeof(cmd_job_t));
+    if (!job) {
+        log_error("calloc job context failed");
+        close(pipefd[0]);
+        /* child will be reaped by sigchld_cb even without a job record */
         return NULL;
     }
 
-    return output;
+    job->pid      = pid;
+    job->pipe_fd  = pipefd[0];
+    job->capacity = 512;
+    job->total    = 0;
+    job->output   = allocate(job->capacity);
+    gettimeofday(&job->start, NULL);
+    strncpy(job->path, path, sizeof(job->path) - 1);
+
+    if (!job->output) {
+        log_error("allocate failed for job output buffer");
+        close(pipefd[0]);
+        free(job);
+        return NULL;
+    }
+
+    /* Register pipe read event (EV_READ | EV_PERSIST) */
+    job->pipe_ev = event_new(g_base, pipefd[0], EV_READ | EV_PERSIST, pipe_read_cb, job);
+    if (!job->pipe_ev) {
+        log_error("event_new for pipe failed");
+        deallocate(job->output);
+        close(pipefd[0]);
+        free(job);
+        return NULL;
+    }
+    event_add(job->pipe_ev, NULL);
+
+    /*
+     * Prepend to global job list.
+     * We re-use the sigchld_ev field as a "next" pointer before the
+     * SIGCHLD event is assigned to this job (it is shared globally,
+     * so we never store it per-job).
+     */
+    job->sigchld_ev     = (struct event *)g_job_list_head;
+    g_job_list_head = job;
+
+    /*
+     * Return immediately.  The caller will send a "202 Accepted" (or
+     * similar) response without waiting for the command to finish.
+     * Output and exit-code are handled asynchronously.
+     */
+    return NULL;
 }
+
+/* ------------------------------------------------------------------ */
+/* Cleanup — call from main()'s shutdown path                          */
+/* ------------------------------------------------------------------ */
+
+void run_cmd_argv_teardown(void) {
+    if (g_sigchld_ev) {
+        event_del(g_sigchld_ev);
+        event_free(g_sigchld_ev);
+        g_sigchld_ev = NULL;
+    }
+    /* Any remaining jobs will leak, but teardown is called at exit */
+    g_job_list_head = NULL;
+}
+
+/* ------------------------------------------------------------------ */
+/* Command wrappers — unchanged public API                             */
+/* ------------------------------------------------------------------ */
 
 char *run_health(int *exit_code) {
     char *argv[] = {"uptime", NULL};

--- a/commands.c
+++ b/commands.c
@@ -1,173 +1,103 @@
-/*
- * commands.c — CMon command execution layer
- *
- * CHANGED (non-blocking rewrite per GitHub issue):
- *  - run_cmd_argv() now forks, sets the pipe read-end O_NONBLOCK,
- *    and returns immediately after a successful fork.
- *  - Output draining and child reaping are handled asynchronously
- *    by the libevent event loop via registered callbacks
- *    (pipe_read_cb and sigchld_cb).
- *  - Both blocking waitpid() calls that existed on the original lines
- *    56 and 108 are gone; all waitpid() calls use WNOHANG.
- *  - Callers (validate_and_run / validate_and_run_arg in main.c)
- *    receive an immediate "job accepted" response; result tracking
- *    is delegated to the separate job-queue project.
- *  - The public API of every command function is unchanged.
- */
-
 #include "commands.h"
 #include "arena.h"
 #include "utils.h"
 #include <errno.h>
 #include <fcntl.h>
-#include <signal.h>
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
-/* libevent headers needed for async I/O and signal handling */
 #include <event2/event.h>
 
 #define SERVER_BINARY "target"
+#define OUTPUT_BUF_INIT 512
 
-/* ------------------------------------------------------------------ */
-/* Job context — one per in-flight command                             */
-/* ------------------------------------------------------------------ */
+// -- Job Context --
 
-/*
- * cmd_job_t tracks everything needed to drain the pipe and reap the
- * child without blocking the event loop.
- *
- * Lifetime: heap-allocated just before fork(); freed inside sigchld_cb
- * once the child has exited and the pipe has been fully drained.
- */
+// Tracks one in-flight command from fork() until the child exits.
+// Arena-allocated before fork(), freed back to arena in sigchld_cb().
+// `next` links all live jobs into a singly-linked list for O(n) PID lookup.
 typedef struct cmd_job {
-    pid_t        pid;           /* child PID                           */
-    int          pipe_fd;       /* read end of the output pipe         */
-    struct event *pipe_ev;      /* libevent READ event on pipe_fd      */
-    struct event *sigchld_ev;   /* libevent SIGCHLD event (shared)     */
-    struct timeval start;       /* wall-clock start time               */
-
-    /* growing output buffer (arena-backed) */
-    char   *output;
-    size_t  capacity;
-    size_t  total;
-
-    /* path string kept for log_exec() */
-    char    path[256];
+    pid_t           pid;
+    int             pipe_fd;
+    struct event   *pipe_ev;
+    struct cmd_job *next;
+    struct timeval  start;
+    char           *output;
+    size_t          capacity;
+    size_t          total;
+    char            path[256];
 } cmd_job_t;
 
-/* ------------------------------------------------------------------ */
-/* Forward declarations of async callbacks                             */
-/* ------------------------------------------------------------------ */
+// -- Module State --
 
-static void pipe_read_cb(evutil_socket_t fd, short what, void *arg);
-static void sigchld_cb(evutil_socket_t sig, short what, void *arg);
+static struct event_base *g_base    = NULL;
+static struct event      *g_sigchld = NULL;
+static cmd_job_t         *g_jobs    = NULL;
 
-/*
- * Global libevent base pointer — set once by run_cmd_argv_set_base()
- * before the first command is dispatched.  The server's main() already
- * holds this value; we just need a reference to it here so the command
- * layer can register events without threading it through every call.
- */
-static struct event_base *g_base = NULL;
+// -- Internal Helpers --
 
-/*
- * Shared SIGCHLD event.  A single evsignal_new is sufficient because
- * SIGCHLD is delivered once per dead child (or coalesced); sigchld_cb
- * loops with waitpid(-1, …, WNOHANG) to reap all pending children.
- */
-static struct event *g_sigchld_ev = NULL;
-
-/*
- * Linked list of active jobs.  sigchld_cb scans this list to match a
- * reaped PID to its cmd_job_t so it can finalise logging and free
- * resources.
- */
-static cmd_job_t *g_job_list_head = NULL;
-
-/* ------------------------------------------------------------------ */
-/* Public initialisation — call once from main() after event_base_new  */
-/* ------------------------------------------------------------------ */
-
-void run_cmd_argv_init(struct event_base *base) {
-    g_base = base;
-
-    /*
-     * Register a persistent SIGCHLD handler.  EV_PERSIST means it
-     * stays active across multiple deliveries, which is what we want.
-     */
-    g_sigchld_ev = evsignal_new(base, SIGCHLD, sigchld_cb, NULL);
-    if (!g_sigchld_ev) {
-        log_error("evsignal_new(SIGCHLD) failed");
-        return;
+static void job_append(cmd_job_t *job, const char *buf, size_t n) {
+    // Grow the arena buffer if this read would overflow it.
+    // Keep 1 byte spare so output[total] = '\0' is always safe.
+    if (job->total + n + 1 > job->capacity) {
+        size_t new_capacity = job->capacity * 2;
+        char *new_output = allocate(new_capacity);
+        if (!new_output) {
+            log_error("allocate failed during output growth");
+            return;
+        }
+        memcpy(new_output, job->output, job->total);
+        deallocate(job->output);
+        job->output = new_output;
+        job->capacity = new_capacity;
     }
-    event_add(g_sigchld_ev, NULL);
+    memcpy(job->output + job->total, buf, n);
+    job->total += n;
 }
 
-/* ------------------------------------------------------------------ */
-/* Async callbacks                                                      */
-/* ------------------------------------------------------------------ */
+static void job_free(cmd_job_t *job, int exit_code) {
+    job->output[job->total] = '\0';
 
-/*
- * pipe_read_cb — called by libevent whenever the child's stdout/stderr
- * pipe has data ready to read (or the write-end has been closed).
- *
- * Because the fd is O_NONBLOCK we read in a tight loop until EAGAIN or
- * EOF.  The output is appended to the job's arena buffer, growing it as
- * needed.
- */
+    struct timeval end;
+    gettimeofday(&end, NULL);
+    double duration = (end.tv_sec - job->start.tv_sec) +
+                      (end.tv_usec - job->start.tv_usec) / 1000000.0;
+
+    log_exec(job->path, exit_code, duration);
+
+    deallocate(job->output);
+    deallocate(job);
+}
+
+// -- Async Callbacks --
+
+// Drain the child's pipe into the job output buffer without blocking.
+// Called by libevent whenever data is available on the pipe read-end.
 static void pipe_read_cb(evutil_socket_t fd, short what, void *arg) {
-    cmd_job_t *job = (cmd_job_t *)arg;
     (void)what;
-
-    char tmp[512];
+    cmd_job_t *job = arg;
+    char temp_buf[OUTPUT_BUF_INIT];
     ssize_t n;
 
-    while ((n = read(fd, tmp, sizeof(tmp))) > 0) {
-        /* Grow arena buffer if needed */
-        if (job->total + (size_t)n >= job->capacity) {
-            size_t new_cap = job->capacity * 2;
-            char *grown = allocate(new_cap);
-            if (!grown) {
-                log_error("allocate failed during pipe_read_cb growth — truncating output");
-                break;
-            }
-            memcpy(grown, job->output, job->total);
-            deallocate(job->output);
-            job->output   = grown;
-            job->capacity = new_cap;
-        }
-        memcpy(job->output + job->total, tmp, (size_t)n);
-        job->total += (size_t)n;
-    }
+    while ((n = read(fd, temp_buf, sizeof(temp_buf))) > 0)
+        job_append(job, temp_buf, n);
 
+    // n == 0 means EOF (child closed its end). Real errors also close the event.
     if (n == 0 || (n == -1 && errno != EAGAIN && errno != EWOULDBLOCK)) {
-        /*
-         * EOF or a real read error — the child has closed its side of
-         * the pipe (i.e., it has exited or its fd was closed).  Stop
-         * listening; sigchld_cb will finalise the job.
-         */
         event_del(job->pipe_ev);
         event_free(job->pipe_ev);
         job->pipe_ev = NULL;
-
         close(job->pipe_fd);
         job->pipe_fd = -1;
     }
-    /* If n == -1 && EAGAIN: no data right now — libevent will call us again */
 }
 
-/*
- * sigchld_cb — called by libevent on SIGCHLD.
- *
- * Reaps all dead children with waitpid(-1, …, WNOHANG) (so we never
- * block), then looks each reaped PID up in g_job_list_head to log
- * the result and free job resources.
- */
+// Reap all exited children without blocking.
+// Called by libevent on SIGCHLD. Loops because the kernel may coalesce
+// multiple signals into one delivery.
 static void sigchld_cb(evutil_socket_t sig, short what, void *arg) {
     (void)sig;
     (void)what;
@@ -176,134 +106,81 @@ static void sigchld_cb(evutil_socket_t sig, short what, void *arg) {
     int status;
     pid_t pid;
 
-    /*
-     * Loop until there are no more children to reap.  This handles
-     * the case where multiple children exit between SIGCHLD deliveries
-     * (the kernel may coalesce signals).
-     */
     while ((pid = waitpid(-1, &status, WNOHANG)) > 0) {
-
-        /* Find the matching job */
+        // Find and unlink the matching job
         cmd_job_t *prev = NULL;
-        cmd_job_t *job  = g_job_list_head;
+        cmd_job_t *job  = g_jobs;
         while (job && job->pid != pid) {
             prev = job;
-            job  = (cmd_job_t *)job->pipe_ev; /* abuse: see note below */
-            /*
-             * NOTE: We cannot store a true "next" pointer inside
-             * cmd_job_t without changing the struct layout visible to
-             * callers.  A simple solution is to keep a parallel singly-
-             * linked list via a separate wrapper; but since the issue
-             * says "no new endpoints, no server changes, no protocol
-             * changes", we embed the next pointer directly below.
-             */
+            job  = job->next;
         }
 
-        /* ---- proper linked-list walk (see struct above for next ptr) ---- */
-        /*
-         * Re-do the walk correctly.  The earlier attempt above is
-         * deliberately left so the reader can see the reasoning; the
-         * compiler will eliminate the dead path.  The actual walk uses
-         * the `sigchld_ev` field temporarily repurposed as `next` before
-         * the event is created — but that is fragile.  Instead we use a
-         * simple singly-linked list embedded in cmd_job_t via the
-         * already-declared field below.  See the revised struct and init
-         * code.
-         */
-        (void)prev; /* suppress unused-variable warning from above */
+        if (!job)
+            continue; // not our child
 
-        if (!job) {
-            /* Not one of ours — could be a pre-existing child */
-            continue;
-        }
-
-        /* -------------------------------------------------------------- */
-        /* Job found: finalise                                              */
-        /* -------------------------------------------------------------- */
-
-        /* Remove from global list */
         if (prev)
-            *((cmd_job_t **)((char *)prev + offsetof(cmd_job_t, sigchld_ev))) = NULL;
+            prev->next = job->next;
         else
-            g_job_list_head = NULL;
+            g_jobs = job->next;
 
-        /* If the pipe event is still active, drain any remaining bytes */
+        // Tear down pipe event if still active
         if (job->pipe_ev) {
             event_del(job->pipe_ev);
             event_free(job->pipe_ev);
             job->pipe_ev = NULL;
         }
+
+        // Final drain — child is dead so the kernel buffer is fixed, won't block
         if (job->pipe_fd >= 0) {
-            /* Final synchronous drain — child is dead so this won't block */
-            char tmp[512];
+            char temp_buf[OUTPUT_BUF_INIT];
             ssize_t n;
-            while ((n = read(job->pipe_fd, tmp, sizeof(tmp))) > 0) {
-                if (job->total + (size_t)n < job->capacity) {
-                    memcpy(job->output + job->total, tmp, (size_t)n);
-                    job->total += (size_t)n;
-                }
-            }
+            while ((n = read(job->pipe_fd, temp_buf, sizeof(temp_buf))) > 0)
+                job_append(job, temp_buf, n);
             close(job->pipe_fd);
             job->pipe_fd = -1;
         }
 
-        /* Null-terminate output */
-        if (job->total >= job->capacity) {
-            /* Rare edge: exactly full — drop last byte for NUL */
-            job->total = job->capacity - 1;
-        }
-        job->output[job->total] = '\0';
-
-        /* Compute duration */
-        struct timeval end;
-        gettimeofday(&end, NULL);
-        double duration = (end.tv_sec  - job->start.tv_sec) +
-                          (end.tv_usec - job->start.tv_usec) / 1000000.0;
-
-        /* Decode exit status */
         int exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
-
-        log_exec(job->path, exit_code, duration);
-
-        /* Free resources */
-        deallocate(job->output);
-        free(job);
+        job_free(job, exit_code);
     }
 }
 
-/* ------------------------------------------------------------------ */
-/* run_cmd_argv — public, now non-blocking                             */
-/* ------------------------------------------------------------------ */
+// -- Lifecycle --
 
-/*
- * CHANGED: This function no longer blocks.
- *
- * It forks the child, sets up the non-blocking pipe, registers async
- * events, and returns immediately.  The return value is always NULL
- * and *exit_code_out is set to 0 ("accepted") so that the existing
- * callers in main.c can send an immediate "job accepted" response
- * to the client.
- *
- * The previous behaviour (wait for child, return output) required two
- * blocking waitpid() calls:
- *   • The error path at (original) line 56 — gone.
- *   • The main reap at (original) line 108 — gone.
- *
- * Both are replaced by the WNOHANG loop in sigchld_cb above.
- */
-char *run_cmd_argv(const char *path, char *const argv[], int *exit_code_out) {
-    if (!g_base) {
-        log_error("run_cmd_argv: event base not set — call run_cmd_argv_init() first");
-        *exit_code_out = -1;
-        return NULL;
+void run_cmd_argv_init(struct event_base *base) {
+    g_base = base;
+    g_sigchld = evsignal_new(base, SIGCHLD, sigchld_cb, NULL);
+    if (!g_sigchld) {
+        log_error("evsignal_new(SIGCHLD) failed");
+        return;
     }
+    event_add(g_sigchld, NULL);
+}
 
-    *exit_code_out = 0; /* "accepted" — actual exit code logged asynchronously */
+void run_cmd_argv_teardown(void) {
+    if (g_sigchld) {
+        event_del(g_sigchld);
+        event_free(g_sigchld);
+        g_sigchld = NULL;
+    }
+    g_jobs = NULL;
+}
+
+// -- Core Executor --
+
+// Previously this function blocked the entire event loop by calling:
+//   waitpid(pid, NULL, 0)  — line 56  (error path after allocate failure)
+//   waitpid(pid, &status, 0) — line 108 (main reap after pipe drain)
+//
+// Now it forks, sets the pipe read-end O_NONBLOCK, arena-allocates a
+// job context, registers a libevent pipe event, and returns immediately.
+// The SIGCHLD handler above reaps the child and logs the result.
+char *run_cmd_argv(const char *path, char *const argv[], int *exit_code_out) {
+    *exit_code_out = -1;
 
     int pipefd[2];
     if (pipe(pipefd) == -1) {
         log_error("pipe failed");
-        *exit_code_out = -1;
         return NULL;
     }
 
@@ -312,120 +189,74 @@ char *run_cmd_argv(const char *path, char *const argv[], int *exit_code_out) {
         log_error("fork failed");
         close(pipefd[0]);
         close(pipefd[1]);
-        *exit_code_out = -1;
         return NULL;
     }
 
     if (pid == 0) {
-        /* ---- child ---- */
+        // child
         dup2(pipefd[1], STDOUT_FILENO);
         dup2(pipefd[1], STDERR_FILENO);
         close(pipefd[0]);
         close(pipefd[1]);
-
         execvp(path, argv);
         fprintf(stderr, "execvp failed: %s\n", path);
         _exit(127);
     }
 
-    /* ---- parent ---- */
-    close(pipefd[1]); /* close write end — child owns it */
+    // parent
+    close(pipefd[1]);
 
-    /* Make the read end non-blocking so pipe_read_cb never stalls */
+    // Make the read-end non-blocking so pipe_read_cb never stalls the event loop
     int flags = fcntl(pipefd[0], F_GETFL, 0);
     if (flags == -1 || fcntl(pipefd[0], F_SETFL, flags | O_NONBLOCK) == -1) {
-        log_error("fcntl O_NONBLOCK failed — falling back to blocking read");
-        /*
-         * Degraded path: if we cannot set O_NONBLOCK we close the fd
-         * and abandon output capture rather than block the event loop.
-         */
+        log_error("fcntl O_NONBLOCK failed");
         close(pipefd[0]);
-        /* sigchld_cb will still reap the child via WNOHANG */
-        cmd_job_t *job_nb = calloc(1, sizeof(cmd_job_t));
-        if (job_nb) {
-            job_nb->pid     = pid;
-            job_nb->pipe_fd = -1;
-            job_nb->output  = allocate(1);
-            if (job_nb->output) job_nb->output[0] = '\0';
-            job_nb->capacity = 1;
-            gettimeofday(&job_nb->start, NULL);
-            strncpy(job_nb->path, path, sizeof(job_nb->path) - 1);
-            /* prepend to global list */
-            job_nb->sigchld_ev   = (struct event *)g_job_list_head;
-            g_job_list_head = job_nb;
-        }
         return NULL;
     }
 
-    /* Allocate job context */
-    cmd_job_t *job = calloc(1, sizeof(cmd_job_t));
+    // Allocate job context from arena
+    cmd_job_t *job = allocate(sizeof(cmd_job_t));
     if (!job) {
-        log_error("calloc job context failed");
+        log_error("allocate failed for job context");
         close(pipefd[0]);
-        /* child will be reaped by sigchld_cb even without a job record */
+        return NULL;
+    }
+    memset(job, 0, sizeof(cmd_job_t));
+
+    job->output = allocate(OUTPUT_BUF_INIT);
+    if (!job->output) {
+        log_error("allocate failed for output buffer");
+        deallocate(job);
+        close(pipefd[0]);
         return NULL;
     }
 
     job->pid      = pid;
     job->pipe_fd  = pipefd[0];
-    job->capacity = 512;
+    job->capacity = OUTPUT_BUF_INIT;
     job->total    = 0;
-    job->output   = allocate(job->capacity);
     gettimeofday(&job->start, NULL);
     strncpy(job->path, path, sizeof(job->path) - 1);
 
-    if (!job->output) {
-        log_error("allocate failed for job output buffer");
-        close(pipefd[0]);
-        free(job);
-        return NULL;
-    }
-
-    /* Register pipe read event (EV_READ | EV_PERSIST) */
     job->pipe_ev = event_new(g_base, pipefd[0], EV_READ | EV_PERSIST, pipe_read_cb, job);
     if (!job->pipe_ev) {
         log_error("event_new for pipe failed");
         deallocate(job->output);
+        deallocate(job);
         close(pipefd[0]);
-        free(job);
         return NULL;
     }
     event_add(job->pipe_ev, NULL);
 
-    /*
-     * Prepend to global job list.
-     * We re-use the sigchld_ev field as a "next" pointer before the
-     * SIGCHLD event is assigned to this job (it is shared globally,
-     * so we never store it per-job).
-     */
-    job->sigchld_ev     = (struct event *)g_job_list_head;
-    g_job_list_head = job;
+    // Prepend to live-job list so sigchld_cb can find it by PID
+    job->next = g_jobs;
+    g_jobs    = job;
 
-    /*
-     * Return immediately.  The caller will send a "202 Accepted" (or
-     * similar) response without waiting for the command to finish.
-     * Output and exit-code are handled asynchronously.
-     */
+    *exit_code_out = 0; // accepted — real exit code is logged asynchronously
     return NULL;
 }
 
-/* ------------------------------------------------------------------ */
-/* Cleanup — call from main()'s shutdown path                          */
-/* ------------------------------------------------------------------ */
-
-void run_cmd_argv_teardown(void) {
-    if (g_sigchld_ev) {
-        event_del(g_sigchld_ev);
-        event_free(g_sigchld_ev);
-        g_sigchld_ev = NULL;
-    }
-    /* Any remaining jobs will leak, but teardown is called at exit */
-    g_job_list_head = NULL;
-}
-
-/* ------------------------------------------------------------------ */
-/* Command wrappers — unchanged public API                             */
-/* ------------------------------------------------------------------ */
+// -- Command Runners --
 
 char *run_health(int *exit_code) {
     char *argv[] = {"uptime", NULL};

--- a/commands.h
+++ b/commands.h
@@ -1,10 +1,37 @@
 #pragma once
 
-// Execute a command, return output (allocated in arena), set exit_code.
-// Returns NULL on execution failure (exit_code set to 127 or similar).
+#include <event2/event.h>
+
+/*
+ * Initialise the async command layer.
+ * Must be called once after event_base_new() in main(), before any
+ * command function is invoked.
+ *
+ * NEW: registers the shared SIGCHLD handler that replaces the two
+ * blocking waitpid() calls that previously lived in run_cmd_argv().
+ */
+void run_cmd_argv_init(struct event_base *base);
+
+/*
+ * Tear down the async command layer.
+ * Call this in main()'s shutdown path, after event_base_loopbreak()
+ * and before event_base_free().
+ */
+void run_cmd_argv_teardown(void);
+
+/*
+ * Execute a command asynchronously.
+ *
+ * CHANGED: no longer blocks.  Forks the child, registers a non-blocking
+ * pipe event and a SIGCHLD handler, then returns NULL immediately.
+ * *exit_code_out is set to 0 ("accepted").  Actual exit-code and output
+ * are processed asynchronously by the event loop.
+ *
+ * Callers should send an immediate HTTP 202 Accepted response.
+ */
 char *run_cmd_argv(const char *path, char *const argv[], int *exit_code);
 
-// Specific runners
+/* Specific runners — public API unchanged */
 char *run_health(int *exit_code);
 char *run_reboot(int *exit_code);
 char *run_restart(int *exit_code);

--- a/commands.h
+++ b/commands.h
@@ -2,36 +2,19 @@
 
 #include <event2/event.h>
 
-/*
- * Initialise the async command layer.
- * Must be called once after event_base_new() in main(), before any
- * command function is invoked.
- *
- * NEW: registers the shared SIGCHLD handler that replaces the two
- * blocking waitpid() calls that previously lived in run_cmd_argv().
- */
+// Initialise async command execution. Must be called once after event_base_new().
+// Registers the SIGCHLD handler that reaps children without blocking the event loop.
 void run_cmd_argv_init(struct event_base *base);
 
-/*
- * Tear down the async command layer.
- * Call this in main()'s shutdown path, after event_base_loopbreak()
- * and before event_base_free().
- */
+// Tear down async command execution. Call before teardown_arena() on shutdown.
 void run_cmd_argv_teardown(void);
 
-/*
- * Execute a command asynchronously.
- *
- * CHANGED: no longer blocks.  Forks the child, registers a non-blocking
- * pipe event and a SIGCHLD handler, then returns NULL immediately.
- * *exit_code_out is set to 0 ("accepted").  Actual exit-code and output
- * are processed asynchronously by the event loop.
- *
- * Callers should send an immediate HTTP 202 Accepted response.
- */
+// Execute a command asynchronously. Forks the child and returns immediately.
+// exit_code is set to 0 (accepted) on success, -1 on fork/pipe failure.
+// Output is captured and logged asynchronously by the event loop.
 char *run_cmd_argv(const char *path, char *const argv[], int *exit_code);
 
-/* Specific runners — public API unchanged */
+// Specific runners
 char *run_health(int *exit_code);
 char *run_reboot(int *exit_code);
 char *run_restart(int *exit_code);

--- a/main.c
+++ b/main.c
@@ -80,12 +80,6 @@ void auth_middleware(struct evhttp_request *req, void *ctx) {
 
 // -- Helpers --
 
-/*
- * CHANGED: run_cmd_argv() is now non-blocking and always returns NULL.
- * We send HTTP 202 Accepted immediately after the fork succeeds, rather
- * than waiting for the child to exit. Output and exit-code are handled
- * asynchronously by the event loop (see commands.c).
- */
 void validate_and_run(struct evhttp_request *req, void *ctx, char *(*runner)(int *)) {
     size_t i = (size_t)(intptr_t)ctx;
     if (evhttp_request_get_command(req) != ROUTES_CONFIG[i].method) {
@@ -94,20 +88,15 @@ void validate_and_run(struct evhttp_request *req, void *ctx, char *(*runner)(int
     }
 
     int exit_code = 0;
-    char *output = runner(&exit_code);
+    runner(&exit_code);
 
-    // run_cmd_argv() is non-blocking: output is always NULL and exit_code
-    // is 0 ("accepted") on a successful fork, or -1 on a hard failure
-    // (pipe/fork error). We respond immediately in both cases.
+    // run_cmd_argv is non-blocking: it forks and returns immediately.
+    // exit_code 0 means the command was accepted, -1 means fork/pipe failed.
     if (exit_code == 0) {
         send_json_response(req, 202, "ok", "Command accepted", NULL);
     } else {
         send_json_response(req, 500, "error", "Command dispatch failed", NULL);
     }
-
-    // output is always NULL in non-blocking mode, but guard anyway
-    if (output)
-        deallocate(output);
 }
 
 void validate_and_run_arg(struct evhttp_request *req, void *ctx,
@@ -121,20 +110,16 @@ void validate_and_run_arg(struct evhttp_request *req, void *ctx,
     char *arg = get_query_param(req, arg_key);
 
     int exit_code = 0;
-    char *output = runner(arg, &exit_code);
+    runner(arg, &exit_code);
 
     if (arg)
         free(arg);
 
-    // Same non-blocking contract as validate_and_run above.
     if (exit_code == 0) {
         send_json_response(req, 202, "ok", "Command accepted", NULL);
     } else {
         send_json_response(req, 500, "error", "Command dispatch failed", NULL);
     }
-
-    if (output)
-        deallocate(output);
 }
 
 // -- Callbacks --
@@ -189,7 +174,7 @@ int main() {
         log_info("Auth module loaded");
     }
 
-    openlog("cmon", LOG_PID | LOG_CONS, LOG_DAEMON); // CHANGED: LOG_LOCAL0 -> LOG_DAEMON
+    openlog("cmon", LOG_PID | LOG_CONS, LOG_DAEMON);
 
     struct event_base *base = event_base_new();
     if (!base) {
@@ -197,8 +182,7 @@ int main() {
         return 1;
     }
 
-    // ADDED: initialise the async command layer and its SIGCHLD handler.
-    // Must be called after event_base_new() and before the event loop starts.
+    // Register the SIGCHLD handler that makes command execution non-blocking
     run_cmd_argv_init(base);
 
     struct evhttp *http_server = evhttp_new(base);
@@ -212,7 +196,8 @@ int main() {
         return 1;
     }
 
-    evhttp_set_allowed_methods(http_server, EVHTTP_REQ_GET | EVHTTP_REQ_POST | EVHTTP_REQ_PUT | EVHTTP_REQ_DELETE);
+    evhttp_set_allowed_methods(http_server, EVHTTP_REQ_GET | EVHTTP_REQ_POST | EVHTTP_REQ_PUT |
+                                                EVHTTP_REQ_DELETE);
 
     for (size_t i = 0; i < NUM_ROUTES; ++i) {
         evhttp_set_cb(http_server, ROUTES_CONFIG[i].path, auth_middleware, (void *)(intptr_t)i);
@@ -228,7 +213,7 @@ int main() {
 
     syslog(LOG_INFO, "Server stopping");
     closelog();
-    run_cmd_argv_teardown(); // ADDED: clean up the SIGCHLD event before arena teardown
+    run_cmd_argv_teardown();
     teardown_arena();
     evhttp_free(http_server);
     event_free(sig_int);

--- a/main.c
+++ b/main.c
@@ -80,6 +80,12 @@ void auth_middleware(struct evhttp_request *req, void *ctx) {
 
 // -- Helpers --
 
+/*
+ * CHANGED: run_cmd_argv() is now non-blocking and always returns NULL.
+ * We send HTTP 202 Accepted immediately after the fork succeeds, rather
+ * than waiting for the child to exit. Output and exit-code are handled
+ * asynchronously by the event loop (see commands.c).
+ */
 void validate_and_run(struct evhttp_request *req, void *ctx, char *(*runner)(int *)) {
     size_t i = (size_t)(intptr_t)ctx;
     if (evhttp_request_get_command(req) != ROUTES_CONFIG[i].method) {
@@ -90,12 +96,16 @@ void validate_and_run(struct evhttp_request *req, void *ctx, char *(*runner)(int
     int exit_code = 0;
     char *output = runner(&exit_code);
 
+    // run_cmd_argv() is non-blocking: output is always NULL and exit_code
+    // is 0 ("accepted") on a successful fork, or -1 on a hard failure
+    // (pipe/fork error). We respond immediately in both cases.
     if (exit_code == 0) {
-        send_json_response(req, 200, "ok", "Command executed", output);
+        send_json_response(req, 202, "ok", "Command accepted", NULL);
     } else {
-        send_json_response(req, 500, "error", "Command failed", output ? output : "Unknown error");
+        send_json_response(req, 500, "error", "Command dispatch failed", NULL);
     }
 
+    // output is always NULL in non-blocking mode, but guard anyway
     if (output)
         deallocate(output);
 }
@@ -116,10 +126,11 @@ void validate_and_run_arg(struct evhttp_request *req, void *ctx,
     if (arg)
         free(arg);
 
+    // Same non-blocking contract as validate_and_run above.
     if (exit_code == 0) {
-        send_json_response(req, 200, "ok", "Command executed", output);
+        send_json_response(req, 202, "ok", "Command accepted", NULL);
     } else {
-        send_json_response(req, 500, "error", "Command failed", output ? output : "Unknown error");
+        send_json_response(req, 500, "error", "Command dispatch failed", NULL);
     }
 
     if (output)
@@ -178,13 +189,17 @@ int main() {
         log_info("Auth module loaded");
     }
 
-    openlog("cmon", LOG_PID | LOG_CONS, LOG_LOCAL0);
+    openlog("cmon", LOG_PID | LOG_CONS, LOG_DAEMON); // CHANGED: LOG_LOCAL0 -> LOG_DAEMON
 
     struct event_base *base = event_base_new();
     if (!base) {
         fprintf(stderr, "Error: Event base is null\n");
         return 1;
     }
+
+    // ADDED: initialise the async command layer and its SIGCHLD handler.
+    // Must be called after event_base_new() and before the event loop starts.
+    run_cmd_argv_init(base);
 
     struct evhttp *http_server = evhttp_new(base);
     if (!http_server) {
@@ -197,8 +212,7 @@ int main() {
         return 1;
     }
 
-    evhttp_set_allowed_methods(http_server, EVHTTP_REQ_GET | EVHTTP_REQ_POST | EVHTTP_REQ_PUT |
-                                                EVHTTP_REQ_DELETE);
+    evhttp_set_allowed_methods(http_server, EVHTTP_REQ_GET | EVHTTP_REQ_POST | EVHTTP_REQ_PUT | EVHTTP_REQ_DELETE);
 
     for (size_t i = 0; i < NUM_ROUTES; ++i) {
         evhttp_set_cb(http_server, ROUTES_CONFIG[i].path, auth_middleware, (void *)(intptr_t)i);
@@ -214,6 +228,7 @@ int main() {
 
     syslog(LOG_INFO, "Server stopping");
     closelog();
+    run_cmd_argv_teardown(); // ADDED: clean up the SIGCHLD event before arena teardown
     teardown_arena();
     evhttp_free(http_server);
     event_free(sig_int);


### PR DESCRIPTION
Fixes #2

## What changed
Replaces the two blocking `waitpid()` calls in `run_cmd_argv`
(original lines 56 and 108) with fully async I/O so the libevent
event loop is never stalled.

## How it works

**pipe_read_cb** — registered with `EV_READ | EV_PERSIST` on the
pipe read-end (set `O_NONBLOCK` after fork). Drains child output
into an arena buffer as data arrives. Never blocks.

**sigchld_cb** — registered with `evsignal_new(base, SIGCHLD, ...)`.
Calls `waitpid(-1, &status, WNOHANG)` in a loop to reap all exited
children. Handles kernel signal coalescing correctly.

**run_cmd_argv** — forks, registers events, returns immediately.
Callers respond HTTP 202 Accepted without waiting for the child.

## Memory
All job context memory goes through the arena (`allocate` /
`deallocate`). No `malloc`, `calloc`, or `free` anywhere.

## Files changed
| File | What changed |
|------|-------------|
| `commands.c` | Non-blocking rewrite of `run_cmd_argv()`. Both `waitpid()` calls removed. |
| `commands.h` | Added `run_cmd_argv_init()` and `run_cmd_argv_teardown()` |
| `main.c` | Call `run_cmd_argv_init(base)` after `event_base_new()`, `run_cmd_argv_teardown()` before `teardown_arena()`, respond 202, fix `LOG_DAEMON` |

## Acceptance criteria
- [x] 30-second command does not block concurrent `/health` requests
- [x] Both `waitpid` calls at lines 56 and 108 are gone
- [x] No `malloc`/`calloc`/`free` — arena only
- [x] Existing test suite passes (`./run_tests.sh`)
- [x] No changes to route table, endpoints, or auth middleware